### PR TITLE
Dependencia inecesaria

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "cookie-parser": "~1.4.4",
-    "debug": "~2.6.9",
     "express": "~4.16.1",
     "http-errors": "~1.6.3",
     "mongodb": "^3.3.3",
@@ -56,7 +55,8 @@
     "eslint-plugin-react": "^7.16.0",
     "nodemon": "^1.19.4",
     "prettier": "^1.18.2",
-    "typescript": "^3.7.2"
+    "typescript": "^3.7.2",
+    "debug": "~2.6.9",
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Hola les sugiero quiter la dependencia de debug, ya que no es necesaria, deberían ponerla en las dependencias de desarrollo.